### PR TITLE
codegen: add WorkloadGroup to Istio groups

### DIFF
--- a/codegen/istio_groups.go
+++ b/codegen/istio_groups.go
@@ -36,6 +36,9 @@ func istioGroups() []model.Group {
 					Kind: "WorkloadEntry",
 				},
 				{
+					Kind: "WorkloadGroup",
+				},
+				{
 					Kind: "VirtualService",
 				},
 				{

--- a/pkg/api/istio/networking.istio.io/v1beta1/clients.go
+++ b/pkg/api/istio/networking.istio.io/v1beta1/clients.go
@@ -49,6 +49,8 @@ type Clientset interface {
 	// clienset for the networking.istio.io/v1beta1/v1beta1 APIs
 	WorkloadEntries() WorkloadEntryClient
 	// clienset for the networking.istio.io/v1beta1/v1beta1 APIs
+	WorkloadGroups() WorkloadGroupClient
+	// clienset for the networking.istio.io/v1beta1/v1beta1 APIs
 	VirtualServices() VirtualServiceClient
 	// clienset for the networking.istio.io/v1beta1/v1beta1 APIs
 	Sidecars() SidecarClient
@@ -94,6 +96,11 @@ func (c *clientSet) ServiceEntries() ServiceEntryClient {
 // clienset for the networking.istio.io/v1beta1/v1beta1 APIs
 func (c *clientSet) WorkloadEntries() WorkloadEntryClient {
 	return NewWorkloadEntryClient(c.client)
+}
+
+// clienset for the networking.istio.io/v1beta1/v1beta1 APIs
+func (c *clientSet) WorkloadGroups() WorkloadGroupClient {
+	return NewWorkloadGroupClient(c.client)
 }
 
 // clienset for the networking.istio.io/v1beta1/v1beta1 APIs
@@ -672,6 +679,148 @@ func (m *multiclusterWorkloadEntryClient) Cluster(cluster string) (WorkloadEntry
 		return nil, err
 	}
 	return NewWorkloadEntryClient(client), nil
+}
+
+// Reader knows how to read and list WorkloadGroups.
+type WorkloadGroupReader interface {
+	// Get retrieves a WorkloadGroup for the given object key
+	GetWorkloadGroup(ctx context.Context, key client.ObjectKey) (*networking_istio_io_v1beta1.WorkloadGroup, error)
+
+	// List retrieves list of WorkloadGroups for a given namespace and list options.
+	ListWorkloadGroup(ctx context.Context, opts ...client.ListOption) (*networking_istio_io_v1beta1.WorkloadGroupList, error)
+}
+
+// WorkloadGroupTransitionFunction instructs the WorkloadGroupWriter how to transition between an existing
+// WorkloadGroup object and a desired on an Upsert
+type WorkloadGroupTransitionFunction func(existing, desired *networking_istio_io_v1beta1.WorkloadGroup) error
+
+// Writer knows how to create, delete, and update WorkloadGroups.
+type WorkloadGroupWriter interface {
+	// Create saves the WorkloadGroup object.
+	CreateWorkloadGroup(ctx context.Context, obj *networking_istio_io_v1beta1.WorkloadGroup, opts ...client.CreateOption) error
+
+	// Delete deletes the WorkloadGroup object.
+	DeleteWorkloadGroup(ctx context.Context, key client.ObjectKey, opts ...client.DeleteOption) error
+
+	// Update updates the given WorkloadGroup object.
+	UpdateWorkloadGroup(ctx context.Context, obj *networking_istio_io_v1beta1.WorkloadGroup, opts ...client.UpdateOption) error
+
+	// Patch patches the given WorkloadGroup object.
+	PatchWorkloadGroup(ctx context.Context, obj *networking_istio_io_v1beta1.WorkloadGroup, patch client.Patch, opts ...client.PatchOption) error
+
+	// DeleteAllOf deletes all WorkloadGroup objects matching the given options.
+	DeleteAllOfWorkloadGroup(ctx context.Context, opts ...client.DeleteAllOfOption) error
+
+	// Create or Update the WorkloadGroup object.
+	UpsertWorkloadGroup(ctx context.Context, obj *networking_istio_io_v1beta1.WorkloadGroup, transitionFuncs ...WorkloadGroupTransitionFunction) error
+}
+
+// StatusWriter knows how to update status subresource of a WorkloadGroup object.
+type WorkloadGroupStatusWriter interface {
+	// Update updates the fields corresponding to the status subresource for the
+	// given WorkloadGroup object.
+	UpdateWorkloadGroupStatus(ctx context.Context, obj *networking_istio_io_v1beta1.WorkloadGroup, opts ...client.UpdateOption) error
+
+	// Patch patches the given WorkloadGroup object's subresource.
+	PatchWorkloadGroupStatus(ctx context.Context, obj *networking_istio_io_v1beta1.WorkloadGroup, patch client.Patch, opts ...client.PatchOption) error
+}
+
+// Client knows how to perform CRUD operations on WorkloadGroups.
+type WorkloadGroupClient interface {
+	WorkloadGroupReader
+	WorkloadGroupWriter
+	WorkloadGroupStatusWriter
+}
+
+type workloadGroupClient struct {
+	client client.Client
+}
+
+func NewWorkloadGroupClient(client client.Client) *workloadGroupClient {
+	return &workloadGroupClient{client: client}
+}
+
+func (c *workloadGroupClient) GetWorkloadGroup(ctx context.Context, key client.ObjectKey) (*networking_istio_io_v1beta1.WorkloadGroup, error) {
+	obj := &networking_istio_io_v1beta1.WorkloadGroup{}
+	if err := c.client.Get(ctx, key, obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+func (c *workloadGroupClient) ListWorkloadGroup(ctx context.Context, opts ...client.ListOption) (*networking_istio_io_v1beta1.WorkloadGroupList, error) {
+	list := &networking_istio_io_v1beta1.WorkloadGroupList{}
+	if err := c.client.List(ctx, list, opts...); err != nil {
+		return nil, err
+	}
+	return list, nil
+}
+
+func (c *workloadGroupClient) CreateWorkloadGroup(ctx context.Context, obj *networking_istio_io_v1beta1.WorkloadGroup, opts ...client.CreateOption) error {
+	return c.client.Create(ctx, obj, opts...)
+}
+
+func (c *workloadGroupClient) DeleteWorkloadGroup(ctx context.Context, key client.ObjectKey, opts ...client.DeleteOption) error {
+	obj := &networking_istio_io_v1beta1.WorkloadGroup{}
+	obj.SetName(key.Name)
+	obj.SetNamespace(key.Namespace)
+	return c.client.Delete(ctx, obj, opts...)
+}
+
+func (c *workloadGroupClient) UpdateWorkloadGroup(ctx context.Context, obj *networking_istio_io_v1beta1.WorkloadGroup, opts ...client.UpdateOption) error {
+	return c.client.Update(ctx, obj, opts...)
+}
+
+func (c *workloadGroupClient) PatchWorkloadGroup(ctx context.Context, obj *networking_istio_io_v1beta1.WorkloadGroup, patch client.Patch, opts ...client.PatchOption) error {
+	return c.client.Patch(ctx, obj, patch, opts...)
+}
+
+func (c *workloadGroupClient) DeleteAllOfWorkloadGroup(ctx context.Context, opts ...client.DeleteAllOfOption) error {
+	obj := &networking_istio_io_v1beta1.WorkloadGroup{}
+	return c.client.DeleteAllOf(ctx, obj, opts...)
+}
+
+func (c *workloadGroupClient) UpsertWorkloadGroup(ctx context.Context, obj *networking_istio_io_v1beta1.WorkloadGroup, transitionFuncs ...WorkloadGroupTransitionFunction) error {
+	genericTxFunc := func(existing, desired runtime.Object) error {
+		for _, txFunc := range transitionFuncs {
+			if err := txFunc(existing.(*networking_istio_io_v1beta1.WorkloadGroup), desired.(*networking_istio_io_v1beta1.WorkloadGroup)); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	_, err := controllerutils.Upsert(ctx, c.client, obj, genericTxFunc)
+	return err
+}
+
+func (c *workloadGroupClient) UpdateWorkloadGroupStatus(ctx context.Context, obj *networking_istio_io_v1beta1.WorkloadGroup, opts ...client.UpdateOption) error {
+	return c.client.Status().Update(ctx, obj, opts...)
+}
+
+func (c *workloadGroupClient) PatchWorkloadGroupStatus(ctx context.Context, obj *networking_istio_io_v1beta1.WorkloadGroup, patch client.Patch, opts ...client.PatchOption) error {
+	return c.client.Status().Patch(ctx, obj, patch, opts...)
+}
+
+// Provides WorkloadGroupClients for multiple clusters.
+type MulticlusterWorkloadGroupClient interface {
+	// Cluster returns a WorkloadGroupClient for the given cluster
+	Cluster(cluster string) (WorkloadGroupClient, error)
+}
+
+type multiclusterWorkloadGroupClient struct {
+	client multicluster.Client
+}
+
+func NewMulticlusterWorkloadGroupClient(client multicluster.Client) MulticlusterWorkloadGroupClient {
+	return &multiclusterWorkloadGroupClient{client: client}
+}
+
+func (m *multiclusterWorkloadGroupClient) Cluster(cluster string) (WorkloadGroupClient, error) {
+	client, err := m.client.Cluster(cluster)
+	if err != nil {
+		return nil, err
+	}
+	return NewWorkloadGroupClient(client), nil
 }
 
 // Reader knows how to read and list VirtualServices.

--- a/pkg/api/istio/networking.istio.io/v1beta1/controller/mocks/event_handlers.go
+++ b/pkg/api/istio/networking.istio.io/v1beta1/controller/mocks/event_handlers.go
@@ -498,6 +498,127 @@ func (mr *MockWorkloadEntryEventWatcherMockRecorder) AddEventHandler(ctx, h inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddEventHandler", reflect.TypeOf((*MockWorkloadEntryEventWatcher)(nil).AddEventHandler), varargs...)
 }
 
+// MockWorkloadGroupEventHandler is a mock of WorkloadGroupEventHandler interface.
+type MockWorkloadGroupEventHandler struct {
+	ctrl     *gomock.Controller
+	recorder *MockWorkloadGroupEventHandlerMockRecorder
+}
+
+// MockWorkloadGroupEventHandlerMockRecorder is the mock recorder for MockWorkloadGroupEventHandler.
+type MockWorkloadGroupEventHandlerMockRecorder struct {
+	mock *MockWorkloadGroupEventHandler
+}
+
+// NewMockWorkloadGroupEventHandler creates a new mock instance.
+func NewMockWorkloadGroupEventHandler(ctrl *gomock.Controller) *MockWorkloadGroupEventHandler {
+	mock := &MockWorkloadGroupEventHandler{ctrl: ctrl}
+	mock.recorder = &MockWorkloadGroupEventHandlerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockWorkloadGroupEventHandler) EXPECT() *MockWorkloadGroupEventHandlerMockRecorder {
+	return m.recorder
+}
+
+// CreateWorkloadGroup mocks base method.
+func (m *MockWorkloadGroupEventHandler) CreateWorkloadGroup(obj *v1beta1.WorkloadGroup) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateWorkloadGroup", obj)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateWorkloadGroup indicates an expected call of CreateWorkloadGroup.
+func (mr *MockWorkloadGroupEventHandlerMockRecorder) CreateWorkloadGroup(obj interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWorkloadGroup", reflect.TypeOf((*MockWorkloadGroupEventHandler)(nil).CreateWorkloadGroup), obj)
+}
+
+// DeleteWorkloadGroup mocks base method.
+func (m *MockWorkloadGroupEventHandler) DeleteWorkloadGroup(obj *v1beta1.WorkloadGroup) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteWorkloadGroup", obj)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteWorkloadGroup indicates an expected call of DeleteWorkloadGroup.
+func (mr *MockWorkloadGroupEventHandlerMockRecorder) DeleteWorkloadGroup(obj interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkloadGroup", reflect.TypeOf((*MockWorkloadGroupEventHandler)(nil).DeleteWorkloadGroup), obj)
+}
+
+// GenericWorkloadGroup mocks base method.
+func (m *MockWorkloadGroupEventHandler) GenericWorkloadGroup(obj *v1beta1.WorkloadGroup) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GenericWorkloadGroup", obj)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GenericWorkloadGroup indicates an expected call of GenericWorkloadGroup.
+func (mr *MockWorkloadGroupEventHandlerMockRecorder) GenericWorkloadGroup(obj interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenericWorkloadGroup", reflect.TypeOf((*MockWorkloadGroupEventHandler)(nil).GenericWorkloadGroup), obj)
+}
+
+// UpdateWorkloadGroup mocks base method.
+func (m *MockWorkloadGroupEventHandler) UpdateWorkloadGroup(old, new *v1beta1.WorkloadGroup) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateWorkloadGroup", old, new)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateWorkloadGroup indicates an expected call of UpdateWorkloadGroup.
+func (mr *MockWorkloadGroupEventHandlerMockRecorder) UpdateWorkloadGroup(old, new interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkloadGroup", reflect.TypeOf((*MockWorkloadGroupEventHandler)(nil).UpdateWorkloadGroup), old, new)
+}
+
+// MockWorkloadGroupEventWatcher is a mock of WorkloadGroupEventWatcher interface.
+type MockWorkloadGroupEventWatcher struct {
+	ctrl     *gomock.Controller
+	recorder *MockWorkloadGroupEventWatcherMockRecorder
+}
+
+// MockWorkloadGroupEventWatcherMockRecorder is the mock recorder for MockWorkloadGroupEventWatcher.
+type MockWorkloadGroupEventWatcherMockRecorder struct {
+	mock *MockWorkloadGroupEventWatcher
+}
+
+// NewMockWorkloadGroupEventWatcher creates a new mock instance.
+func NewMockWorkloadGroupEventWatcher(ctrl *gomock.Controller) *MockWorkloadGroupEventWatcher {
+	mock := &MockWorkloadGroupEventWatcher{ctrl: ctrl}
+	mock.recorder = &MockWorkloadGroupEventWatcherMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockWorkloadGroupEventWatcher) EXPECT() *MockWorkloadGroupEventWatcherMockRecorder {
+	return m.recorder
+}
+
+// AddEventHandler mocks base method.
+func (m *MockWorkloadGroupEventWatcher) AddEventHandler(ctx context.Context, h controller.WorkloadGroupEventHandler, predicates ...predicate.Predicate) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, h}
+	for _, a := range predicates {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "AddEventHandler", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddEventHandler indicates an expected call of AddEventHandler.
+func (mr *MockWorkloadGroupEventWatcherMockRecorder) AddEventHandler(ctx, h interface{}, predicates ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, h}, predicates...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddEventHandler", reflect.TypeOf((*MockWorkloadGroupEventWatcher)(nil).AddEventHandler), varargs...)
+}
+
 // MockVirtualServiceEventHandler is a mock of VirtualServiceEventHandler interface.
 type MockVirtualServiceEventHandler struct {
 	ctrl     *gomock.Controller

--- a/pkg/api/istio/networking.istio.io/v1beta1/controller/mocks/multicluster_reconcilers.go
+++ b/pkg/api/istio/networking.istio.io/v1beta1/controller/mocks/multicluster_reconcilers.go
@@ -475,6 +475,121 @@ func (mr *MockMulticlusterWorkloadEntryReconcileLoopMockRecorder) AddMulticluste
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddMulticlusterWorkloadEntryReconciler", reflect.TypeOf((*MockMulticlusterWorkloadEntryReconcileLoop)(nil).AddMulticlusterWorkloadEntryReconciler), varargs...)
 }
 
+// MockMulticlusterWorkloadGroupReconciler is a mock of MulticlusterWorkloadGroupReconciler interface.
+type MockMulticlusterWorkloadGroupReconciler struct {
+	ctrl     *gomock.Controller
+	recorder *MockMulticlusterWorkloadGroupReconcilerMockRecorder
+}
+
+// MockMulticlusterWorkloadGroupReconcilerMockRecorder is the mock recorder for MockMulticlusterWorkloadGroupReconciler.
+type MockMulticlusterWorkloadGroupReconcilerMockRecorder struct {
+	mock *MockMulticlusterWorkloadGroupReconciler
+}
+
+// NewMockMulticlusterWorkloadGroupReconciler creates a new mock instance.
+func NewMockMulticlusterWorkloadGroupReconciler(ctrl *gomock.Controller) *MockMulticlusterWorkloadGroupReconciler {
+	mock := &MockMulticlusterWorkloadGroupReconciler{ctrl: ctrl}
+	mock.recorder = &MockMulticlusterWorkloadGroupReconcilerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockMulticlusterWorkloadGroupReconciler) EXPECT() *MockMulticlusterWorkloadGroupReconcilerMockRecorder {
+	return m.recorder
+}
+
+// ReconcileWorkloadGroup mocks base method.
+func (m *MockMulticlusterWorkloadGroupReconciler) ReconcileWorkloadGroup(clusterName string, obj *v1beta1.WorkloadGroup) (reconcile.Result, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReconcileWorkloadGroup", clusterName, obj)
+	ret0, _ := ret[0].(reconcile.Result)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReconcileWorkloadGroup indicates an expected call of ReconcileWorkloadGroup.
+func (mr *MockMulticlusterWorkloadGroupReconcilerMockRecorder) ReconcileWorkloadGroup(clusterName, obj interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileWorkloadGroup", reflect.TypeOf((*MockMulticlusterWorkloadGroupReconciler)(nil).ReconcileWorkloadGroup), clusterName, obj)
+}
+
+// MockMulticlusterWorkloadGroupDeletionReconciler is a mock of MulticlusterWorkloadGroupDeletionReconciler interface.
+type MockMulticlusterWorkloadGroupDeletionReconciler struct {
+	ctrl     *gomock.Controller
+	recorder *MockMulticlusterWorkloadGroupDeletionReconcilerMockRecorder
+}
+
+// MockMulticlusterWorkloadGroupDeletionReconcilerMockRecorder is the mock recorder for MockMulticlusterWorkloadGroupDeletionReconciler.
+type MockMulticlusterWorkloadGroupDeletionReconcilerMockRecorder struct {
+	mock *MockMulticlusterWorkloadGroupDeletionReconciler
+}
+
+// NewMockMulticlusterWorkloadGroupDeletionReconciler creates a new mock instance.
+func NewMockMulticlusterWorkloadGroupDeletionReconciler(ctrl *gomock.Controller) *MockMulticlusterWorkloadGroupDeletionReconciler {
+	mock := &MockMulticlusterWorkloadGroupDeletionReconciler{ctrl: ctrl}
+	mock.recorder = &MockMulticlusterWorkloadGroupDeletionReconcilerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockMulticlusterWorkloadGroupDeletionReconciler) EXPECT() *MockMulticlusterWorkloadGroupDeletionReconcilerMockRecorder {
+	return m.recorder
+}
+
+// ReconcileWorkloadGroupDeletion mocks base method.
+func (m *MockMulticlusterWorkloadGroupDeletionReconciler) ReconcileWorkloadGroupDeletion(clusterName string, req reconcile.Request) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReconcileWorkloadGroupDeletion", clusterName, req)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReconcileWorkloadGroupDeletion indicates an expected call of ReconcileWorkloadGroupDeletion.
+func (mr *MockMulticlusterWorkloadGroupDeletionReconcilerMockRecorder) ReconcileWorkloadGroupDeletion(clusterName, req interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileWorkloadGroupDeletion", reflect.TypeOf((*MockMulticlusterWorkloadGroupDeletionReconciler)(nil).ReconcileWorkloadGroupDeletion), clusterName, req)
+}
+
+// MockMulticlusterWorkloadGroupReconcileLoop is a mock of MulticlusterWorkloadGroupReconcileLoop interface.
+type MockMulticlusterWorkloadGroupReconcileLoop struct {
+	ctrl     *gomock.Controller
+	recorder *MockMulticlusterWorkloadGroupReconcileLoopMockRecorder
+}
+
+// MockMulticlusterWorkloadGroupReconcileLoopMockRecorder is the mock recorder for MockMulticlusterWorkloadGroupReconcileLoop.
+type MockMulticlusterWorkloadGroupReconcileLoopMockRecorder struct {
+	mock *MockMulticlusterWorkloadGroupReconcileLoop
+}
+
+// NewMockMulticlusterWorkloadGroupReconcileLoop creates a new mock instance.
+func NewMockMulticlusterWorkloadGroupReconcileLoop(ctrl *gomock.Controller) *MockMulticlusterWorkloadGroupReconcileLoop {
+	mock := &MockMulticlusterWorkloadGroupReconcileLoop{ctrl: ctrl}
+	mock.recorder = &MockMulticlusterWorkloadGroupReconcileLoopMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockMulticlusterWorkloadGroupReconcileLoop) EXPECT() *MockMulticlusterWorkloadGroupReconcileLoopMockRecorder {
+	return m.recorder
+}
+
+// AddMulticlusterWorkloadGroupReconciler mocks base method.
+func (m *MockMulticlusterWorkloadGroupReconcileLoop) AddMulticlusterWorkloadGroupReconciler(ctx context.Context, rec controller.MulticlusterWorkloadGroupReconciler, predicates ...predicate.Predicate) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, rec}
+	for _, a := range predicates {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "AddMulticlusterWorkloadGroupReconciler", varargs...)
+}
+
+// AddMulticlusterWorkloadGroupReconciler indicates an expected call of AddMulticlusterWorkloadGroupReconciler.
+func (mr *MockMulticlusterWorkloadGroupReconcileLoopMockRecorder) AddMulticlusterWorkloadGroupReconciler(ctx, rec interface{}, predicates ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, rec}, predicates...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddMulticlusterWorkloadGroupReconciler", reflect.TypeOf((*MockMulticlusterWorkloadGroupReconcileLoop)(nil).AddMulticlusterWorkloadGroupReconciler), varargs...)
+}
+
 // MockMulticlusterVirtualServiceReconciler is a mock of MulticlusterVirtualServiceReconciler interface.
 type MockMulticlusterVirtualServiceReconciler struct {
 	ctrl     *gomock.Controller

--- a/pkg/api/istio/networking.istio.io/v1beta1/controller/mocks/reconcilers.go
+++ b/pkg/api/istio/networking.istio.io/v1beta1/controller/mocks/reconcilers.go
@@ -747,6 +747,189 @@ func (mr *MockWorkloadEntryReconcileLoopMockRecorder) RunWorkloadEntryReconciler
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunWorkloadEntryReconciler", reflect.TypeOf((*MockWorkloadEntryReconcileLoop)(nil).RunWorkloadEntryReconciler), varargs...)
 }
 
+// MockWorkloadGroupReconciler is a mock of WorkloadGroupReconciler interface.
+type MockWorkloadGroupReconciler struct {
+	ctrl     *gomock.Controller
+	recorder *MockWorkloadGroupReconcilerMockRecorder
+}
+
+// MockWorkloadGroupReconcilerMockRecorder is the mock recorder for MockWorkloadGroupReconciler.
+type MockWorkloadGroupReconcilerMockRecorder struct {
+	mock *MockWorkloadGroupReconciler
+}
+
+// NewMockWorkloadGroupReconciler creates a new mock instance.
+func NewMockWorkloadGroupReconciler(ctrl *gomock.Controller) *MockWorkloadGroupReconciler {
+	mock := &MockWorkloadGroupReconciler{ctrl: ctrl}
+	mock.recorder = &MockWorkloadGroupReconcilerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockWorkloadGroupReconciler) EXPECT() *MockWorkloadGroupReconcilerMockRecorder {
+	return m.recorder
+}
+
+// ReconcileWorkloadGroup mocks base method.
+func (m *MockWorkloadGroupReconciler) ReconcileWorkloadGroup(obj *v1beta1.WorkloadGroup) (reconcile.Result, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReconcileWorkloadGroup", obj)
+	ret0, _ := ret[0].(reconcile.Result)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReconcileWorkloadGroup indicates an expected call of ReconcileWorkloadGroup.
+func (mr *MockWorkloadGroupReconcilerMockRecorder) ReconcileWorkloadGroup(obj interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileWorkloadGroup", reflect.TypeOf((*MockWorkloadGroupReconciler)(nil).ReconcileWorkloadGroup), obj)
+}
+
+// MockWorkloadGroupDeletionReconciler is a mock of WorkloadGroupDeletionReconciler interface.
+type MockWorkloadGroupDeletionReconciler struct {
+	ctrl     *gomock.Controller
+	recorder *MockWorkloadGroupDeletionReconcilerMockRecorder
+}
+
+// MockWorkloadGroupDeletionReconcilerMockRecorder is the mock recorder for MockWorkloadGroupDeletionReconciler.
+type MockWorkloadGroupDeletionReconcilerMockRecorder struct {
+	mock *MockWorkloadGroupDeletionReconciler
+}
+
+// NewMockWorkloadGroupDeletionReconciler creates a new mock instance.
+func NewMockWorkloadGroupDeletionReconciler(ctrl *gomock.Controller) *MockWorkloadGroupDeletionReconciler {
+	mock := &MockWorkloadGroupDeletionReconciler{ctrl: ctrl}
+	mock.recorder = &MockWorkloadGroupDeletionReconcilerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockWorkloadGroupDeletionReconciler) EXPECT() *MockWorkloadGroupDeletionReconcilerMockRecorder {
+	return m.recorder
+}
+
+// ReconcileWorkloadGroupDeletion mocks base method.
+func (m *MockWorkloadGroupDeletionReconciler) ReconcileWorkloadGroupDeletion(req reconcile.Request) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReconcileWorkloadGroupDeletion", req)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReconcileWorkloadGroupDeletion indicates an expected call of ReconcileWorkloadGroupDeletion.
+func (mr *MockWorkloadGroupDeletionReconcilerMockRecorder) ReconcileWorkloadGroupDeletion(req interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileWorkloadGroupDeletion", reflect.TypeOf((*MockWorkloadGroupDeletionReconciler)(nil).ReconcileWorkloadGroupDeletion), req)
+}
+
+// MockWorkloadGroupFinalizer is a mock of WorkloadGroupFinalizer interface.
+type MockWorkloadGroupFinalizer struct {
+	ctrl     *gomock.Controller
+	recorder *MockWorkloadGroupFinalizerMockRecorder
+}
+
+// MockWorkloadGroupFinalizerMockRecorder is the mock recorder for MockWorkloadGroupFinalizer.
+type MockWorkloadGroupFinalizerMockRecorder struct {
+	mock *MockWorkloadGroupFinalizer
+}
+
+// NewMockWorkloadGroupFinalizer creates a new mock instance.
+func NewMockWorkloadGroupFinalizer(ctrl *gomock.Controller) *MockWorkloadGroupFinalizer {
+	mock := &MockWorkloadGroupFinalizer{ctrl: ctrl}
+	mock.recorder = &MockWorkloadGroupFinalizerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockWorkloadGroupFinalizer) EXPECT() *MockWorkloadGroupFinalizerMockRecorder {
+	return m.recorder
+}
+
+// FinalizeWorkloadGroup mocks base method.
+func (m *MockWorkloadGroupFinalizer) FinalizeWorkloadGroup(obj *v1beta1.WorkloadGroup) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FinalizeWorkloadGroup", obj)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// FinalizeWorkloadGroup indicates an expected call of FinalizeWorkloadGroup.
+func (mr *MockWorkloadGroupFinalizerMockRecorder) FinalizeWorkloadGroup(obj interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinalizeWorkloadGroup", reflect.TypeOf((*MockWorkloadGroupFinalizer)(nil).FinalizeWorkloadGroup), obj)
+}
+
+// ReconcileWorkloadGroup mocks base method.
+func (m *MockWorkloadGroupFinalizer) ReconcileWorkloadGroup(obj *v1beta1.WorkloadGroup) (reconcile.Result, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReconcileWorkloadGroup", obj)
+	ret0, _ := ret[0].(reconcile.Result)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReconcileWorkloadGroup indicates an expected call of ReconcileWorkloadGroup.
+func (mr *MockWorkloadGroupFinalizerMockRecorder) ReconcileWorkloadGroup(obj interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileWorkloadGroup", reflect.TypeOf((*MockWorkloadGroupFinalizer)(nil).ReconcileWorkloadGroup), obj)
+}
+
+// WorkloadGroupFinalizerName mocks base method.
+func (m *MockWorkloadGroupFinalizer) WorkloadGroupFinalizerName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WorkloadGroupFinalizerName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// WorkloadGroupFinalizerName indicates an expected call of WorkloadGroupFinalizerName.
+func (mr *MockWorkloadGroupFinalizerMockRecorder) WorkloadGroupFinalizerName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadGroupFinalizerName", reflect.TypeOf((*MockWorkloadGroupFinalizer)(nil).WorkloadGroupFinalizerName))
+}
+
+// MockWorkloadGroupReconcileLoop is a mock of WorkloadGroupReconcileLoop interface.
+type MockWorkloadGroupReconcileLoop struct {
+	ctrl     *gomock.Controller
+	recorder *MockWorkloadGroupReconcileLoopMockRecorder
+}
+
+// MockWorkloadGroupReconcileLoopMockRecorder is the mock recorder for MockWorkloadGroupReconcileLoop.
+type MockWorkloadGroupReconcileLoopMockRecorder struct {
+	mock *MockWorkloadGroupReconcileLoop
+}
+
+// NewMockWorkloadGroupReconcileLoop creates a new mock instance.
+func NewMockWorkloadGroupReconcileLoop(ctrl *gomock.Controller) *MockWorkloadGroupReconcileLoop {
+	mock := &MockWorkloadGroupReconcileLoop{ctrl: ctrl}
+	mock.recorder = &MockWorkloadGroupReconcileLoopMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockWorkloadGroupReconcileLoop) EXPECT() *MockWorkloadGroupReconcileLoopMockRecorder {
+	return m.recorder
+}
+
+// RunWorkloadGroupReconciler mocks base method.
+func (m *MockWorkloadGroupReconcileLoop) RunWorkloadGroupReconciler(ctx context.Context, rec controller.WorkloadGroupReconciler, predicates ...predicate.Predicate) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, rec}
+	for _, a := range predicates {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RunWorkloadGroupReconciler", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RunWorkloadGroupReconciler indicates an expected call of RunWorkloadGroupReconciler.
+func (mr *MockWorkloadGroupReconcileLoopMockRecorder) RunWorkloadGroupReconciler(ctx, rec interface{}, predicates ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, rec}, predicates...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunWorkloadGroupReconciler", reflect.TypeOf((*MockWorkloadGroupReconcileLoop)(nil).RunWorkloadGroupReconciler), varargs...)
+}
+
 // MockVirtualServiceReconciler is a mock of VirtualServiceReconciler interface.
 type MockVirtualServiceReconciler struct {
 	ctrl     *gomock.Controller

--- a/pkg/api/istio/networking.istio.io/v1beta1/mocks/clients.go
+++ b/pkg/api/istio/networking.istio.io/v1beta1/mocks/clients.go
@@ -159,6 +159,20 @@ func (mr *MockClientsetMockRecorder) WorkloadEntries() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadEntries", reflect.TypeOf((*MockClientset)(nil).WorkloadEntries))
 }
 
+// WorkloadGroups mocks base method.
+func (m *MockClientset) WorkloadGroups() v1beta1.WorkloadGroupClient {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WorkloadGroups")
+	ret0, _ := ret[0].(v1beta1.WorkloadGroupClient)
+	return ret0
+}
+
+// WorkloadGroups indicates an expected call of WorkloadGroups.
+func (mr *MockClientsetMockRecorder) WorkloadGroups() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadGroups", reflect.TypeOf((*MockClientset)(nil).WorkloadGroups))
+}
+
 // MockDestinationRuleReader is a mock of DestinationRuleReader interface.
 type MockDestinationRuleReader struct {
 	ctrl     *gomock.Controller
@@ -2173,6 +2187,510 @@ func (m *MockMulticlusterWorkloadEntryClient) Cluster(cluster string) (v1beta1.W
 func (mr *MockMulticlusterWorkloadEntryClientMockRecorder) Cluster(cluster interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cluster", reflect.TypeOf((*MockMulticlusterWorkloadEntryClient)(nil).Cluster), cluster)
+}
+
+// MockWorkloadGroupReader is a mock of WorkloadGroupReader interface.
+type MockWorkloadGroupReader struct {
+	ctrl     *gomock.Controller
+	recorder *MockWorkloadGroupReaderMockRecorder
+}
+
+// MockWorkloadGroupReaderMockRecorder is the mock recorder for MockWorkloadGroupReader.
+type MockWorkloadGroupReaderMockRecorder struct {
+	mock *MockWorkloadGroupReader
+}
+
+// NewMockWorkloadGroupReader creates a new mock instance.
+func NewMockWorkloadGroupReader(ctrl *gomock.Controller) *MockWorkloadGroupReader {
+	mock := &MockWorkloadGroupReader{ctrl: ctrl}
+	mock.recorder = &MockWorkloadGroupReaderMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockWorkloadGroupReader) EXPECT() *MockWorkloadGroupReaderMockRecorder {
+	return m.recorder
+}
+
+// GetWorkloadGroup mocks base method.
+func (m *MockWorkloadGroupReader) GetWorkloadGroup(ctx context.Context, key client.ObjectKey) (*v1beta10.WorkloadGroup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWorkloadGroup", ctx, key)
+	ret0, _ := ret[0].(*v1beta10.WorkloadGroup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetWorkloadGroup indicates an expected call of GetWorkloadGroup.
+func (mr *MockWorkloadGroupReaderMockRecorder) GetWorkloadGroup(ctx, key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkloadGroup", reflect.TypeOf((*MockWorkloadGroupReader)(nil).GetWorkloadGroup), ctx, key)
+}
+
+// ListWorkloadGroup mocks base method.
+func (m *MockWorkloadGroupReader) ListWorkloadGroup(ctx context.Context, opts ...client.ListOption) (*v1beta10.WorkloadGroupList, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListWorkloadGroup", varargs...)
+	ret0, _ := ret[0].(*v1beta10.WorkloadGroupList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListWorkloadGroup indicates an expected call of ListWorkloadGroup.
+func (mr *MockWorkloadGroupReaderMockRecorder) ListWorkloadGroup(ctx interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWorkloadGroup", reflect.TypeOf((*MockWorkloadGroupReader)(nil).ListWorkloadGroup), varargs...)
+}
+
+// MockWorkloadGroupWriter is a mock of WorkloadGroupWriter interface.
+type MockWorkloadGroupWriter struct {
+	ctrl     *gomock.Controller
+	recorder *MockWorkloadGroupWriterMockRecorder
+}
+
+// MockWorkloadGroupWriterMockRecorder is the mock recorder for MockWorkloadGroupWriter.
+type MockWorkloadGroupWriterMockRecorder struct {
+	mock *MockWorkloadGroupWriter
+}
+
+// NewMockWorkloadGroupWriter creates a new mock instance.
+func NewMockWorkloadGroupWriter(ctrl *gomock.Controller) *MockWorkloadGroupWriter {
+	mock := &MockWorkloadGroupWriter{ctrl: ctrl}
+	mock.recorder = &MockWorkloadGroupWriterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockWorkloadGroupWriter) EXPECT() *MockWorkloadGroupWriterMockRecorder {
+	return m.recorder
+}
+
+// CreateWorkloadGroup mocks base method.
+func (m *MockWorkloadGroupWriter) CreateWorkloadGroup(ctx context.Context, obj *v1beta10.WorkloadGroup, opts ...client.CreateOption) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, obj}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateWorkloadGroup", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateWorkloadGroup indicates an expected call of CreateWorkloadGroup.
+func (mr *MockWorkloadGroupWriterMockRecorder) CreateWorkloadGroup(ctx, obj interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, obj}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWorkloadGroup", reflect.TypeOf((*MockWorkloadGroupWriter)(nil).CreateWorkloadGroup), varargs...)
+}
+
+// DeleteAllOfWorkloadGroup mocks base method.
+func (m *MockWorkloadGroupWriter) DeleteAllOfWorkloadGroup(ctx context.Context, opts ...client.DeleteAllOfOption) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteAllOfWorkloadGroup", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteAllOfWorkloadGroup indicates an expected call of DeleteAllOfWorkloadGroup.
+func (mr *MockWorkloadGroupWriterMockRecorder) DeleteAllOfWorkloadGroup(ctx interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAllOfWorkloadGroup", reflect.TypeOf((*MockWorkloadGroupWriter)(nil).DeleteAllOfWorkloadGroup), varargs...)
+}
+
+// DeleteWorkloadGroup mocks base method.
+func (m *MockWorkloadGroupWriter) DeleteWorkloadGroup(ctx context.Context, key client.ObjectKey, opts ...client.DeleteOption) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, key}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteWorkloadGroup", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteWorkloadGroup indicates an expected call of DeleteWorkloadGroup.
+func (mr *MockWorkloadGroupWriterMockRecorder) DeleteWorkloadGroup(ctx, key interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, key}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkloadGroup", reflect.TypeOf((*MockWorkloadGroupWriter)(nil).DeleteWorkloadGroup), varargs...)
+}
+
+// PatchWorkloadGroup mocks base method.
+func (m *MockWorkloadGroupWriter) PatchWorkloadGroup(ctx context.Context, obj *v1beta10.WorkloadGroup, patch client.Patch, opts ...client.PatchOption) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, obj, patch}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "PatchWorkloadGroup", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PatchWorkloadGroup indicates an expected call of PatchWorkloadGroup.
+func (mr *MockWorkloadGroupWriterMockRecorder) PatchWorkloadGroup(ctx, obj, patch interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, obj, patch}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchWorkloadGroup", reflect.TypeOf((*MockWorkloadGroupWriter)(nil).PatchWorkloadGroup), varargs...)
+}
+
+// UpdateWorkloadGroup mocks base method.
+func (m *MockWorkloadGroupWriter) UpdateWorkloadGroup(ctx context.Context, obj *v1beta10.WorkloadGroup, opts ...client.UpdateOption) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, obj}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpdateWorkloadGroup", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateWorkloadGroup indicates an expected call of UpdateWorkloadGroup.
+func (mr *MockWorkloadGroupWriterMockRecorder) UpdateWorkloadGroup(ctx, obj interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, obj}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkloadGroup", reflect.TypeOf((*MockWorkloadGroupWriter)(nil).UpdateWorkloadGroup), varargs...)
+}
+
+// UpsertWorkloadGroup mocks base method.
+func (m *MockWorkloadGroupWriter) UpsertWorkloadGroup(ctx context.Context, obj *v1beta10.WorkloadGroup, transitionFuncs ...v1beta1.WorkloadGroupTransitionFunction) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, obj}
+	for _, a := range transitionFuncs {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpsertWorkloadGroup", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpsertWorkloadGroup indicates an expected call of UpsertWorkloadGroup.
+func (mr *MockWorkloadGroupWriterMockRecorder) UpsertWorkloadGroup(ctx, obj interface{}, transitionFuncs ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, obj}, transitionFuncs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertWorkloadGroup", reflect.TypeOf((*MockWorkloadGroupWriter)(nil).UpsertWorkloadGroup), varargs...)
+}
+
+// MockWorkloadGroupStatusWriter is a mock of WorkloadGroupStatusWriter interface.
+type MockWorkloadGroupStatusWriter struct {
+	ctrl     *gomock.Controller
+	recorder *MockWorkloadGroupStatusWriterMockRecorder
+}
+
+// MockWorkloadGroupStatusWriterMockRecorder is the mock recorder for MockWorkloadGroupStatusWriter.
+type MockWorkloadGroupStatusWriterMockRecorder struct {
+	mock *MockWorkloadGroupStatusWriter
+}
+
+// NewMockWorkloadGroupStatusWriter creates a new mock instance.
+func NewMockWorkloadGroupStatusWriter(ctrl *gomock.Controller) *MockWorkloadGroupStatusWriter {
+	mock := &MockWorkloadGroupStatusWriter{ctrl: ctrl}
+	mock.recorder = &MockWorkloadGroupStatusWriterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockWorkloadGroupStatusWriter) EXPECT() *MockWorkloadGroupStatusWriterMockRecorder {
+	return m.recorder
+}
+
+// PatchWorkloadGroupStatus mocks base method.
+func (m *MockWorkloadGroupStatusWriter) PatchWorkloadGroupStatus(ctx context.Context, obj *v1beta10.WorkloadGroup, patch client.Patch, opts ...client.PatchOption) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, obj, patch}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "PatchWorkloadGroupStatus", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PatchWorkloadGroupStatus indicates an expected call of PatchWorkloadGroupStatus.
+func (mr *MockWorkloadGroupStatusWriterMockRecorder) PatchWorkloadGroupStatus(ctx, obj, patch interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, obj, patch}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchWorkloadGroupStatus", reflect.TypeOf((*MockWorkloadGroupStatusWriter)(nil).PatchWorkloadGroupStatus), varargs...)
+}
+
+// UpdateWorkloadGroupStatus mocks base method.
+func (m *MockWorkloadGroupStatusWriter) UpdateWorkloadGroupStatus(ctx context.Context, obj *v1beta10.WorkloadGroup, opts ...client.UpdateOption) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, obj}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpdateWorkloadGroupStatus", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateWorkloadGroupStatus indicates an expected call of UpdateWorkloadGroupStatus.
+func (mr *MockWorkloadGroupStatusWriterMockRecorder) UpdateWorkloadGroupStatus(ctx, obj interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, obj}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkloadGroupStatus", reflect.TypeOf((*MockWorkloadGroupStatusWriter)(nil).UpdateWorkloadGroupStatus), varargs...)
+}
+
+// MockWorkloadGroupClient is a mock of WorkloadGroupClient interface.
+type MockWorkloadGroupClient struct {
+	ctrl     *gomock.Controller
+	recorder *MockWorkloadGroupClientMockRecorder
+}
+
+// MockWorkloadGroupClientMockRecorder is the mock recorder for MockWorkloadGroupClient.
+type MockWorkloadGroupClientMockRecorder struct {
+	mock *MockWorkloadGroupClient
+}
+
+// NewMockWorkloadGroupClient creates a new mock instance.
+func NewMockWorkloadGroupClient(ctrl *gomock.Controller) *MockWorkloadGroupClient {
+	mock := &MockWorkloadGroupClient{ctrl: ctrl}
+	mock.recorder = &MockWorkloadGroupClientMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockWorkloadGroupClient) EXPECT() *MockWorkloadGroupClientMockRecorder {
+	return m.recorder
+}
+
+// CreateWorkloadGroup mocks base method.
+func (m *MockWorkloadGroupClient) CreateWorkloadGroup(ctx context.Context, obj *v1beta10.WorkloadGroup, opts ...client.CreateOption) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, obj}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateWorkloadGroup", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateWorkloadGroup indicates an expected call of CreateWorkloadGroup.
+func (mr *MockWorkloadGroupClientMockRecorder) CreateWorkloadGroup(ctx, obj interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, obj}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWorkloadGroup", reflect.TypeOf((*MockWorkloadGroupClient)(nil).CreateWorkloadGroup), varargs...)
+}
+
+// DeleteAllOfWorkloadGroup mocks base method.
+func (m *MockWorkloadGroupClient) DeleteAllOfWorkloadGroup(ctx context.Context, opts ...client.DeleteAllOfOption) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteAllOfWorkloadGroup", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteAllOfWorkloadGroup indicates an expected call of DeleteAllOfWorkloadGroup.
+func (mr *MockWorkloadGroupClientMockRecorder) DeleteAllOfWorkloadGroup(ctx interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAllOfWorkloadGroup", reflect.TypeOf((*MockWorkloadGroupClient)(nil).DeleteAllOfWorkloadGroup), varargs...)
+}
+
+// DeleteWorkloadGroup mocks base method.
+func (m *MockWorkloadGroupClient) DeleteWorkloadGroup(ctx context.Context, key client.ObjectKey, opts ...client.DeleteOption) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, key}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteWorkloadGroup", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteWorkloadGroup indicates an expected call of DeleteWorkloadGroup.
+func (mr *MockWorkloadGroupClientMockRecorder) DeleteWorkloadGroup(ctx, key interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, key}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkloadGroup", reflect.TypeOf((*MockWorkloadGroupClient)(nil).DeleteWorkloadGroup), varargs...)
+}
+
+// GetWorkloadGroup mocks base method.
+func (m *MockWorkloadGroupClient) GetWorkloadGroup(ctx context.Context, key client.ObjectKey) (*v1beta10.WorkloadGroup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWorkloadGroup", ctx, key)
+	ret0, _ := ret[0].(*v1beta10.WorkloadGroup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetWorkloadGroup indicates an expected call of GetWorkloadGroup.
+func (mr *MockWorkloadGroupClientMockRecorder) GetWorkloadGroup(ctx, key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkloadGroup", reflect.TypeOf((*MockWorkloadGroupClient)(nil).GetWorkloadGroup), ctx, key)
+}
+
+// ListWorkloadGroup mocks base method.
+func (m *MockWorkloadGroupClient) ListWorkloadGroup(ctx context.Context, opts ...client.ListOption) (*v1beta10.WorkloadGroupList, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListWorkloadGroup", varargs...)
+	ret0, _ := ret[0].(*v1beta10.WorkloadGroupList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListWorkloadGroup indicates an expected call of ListWorkloadGroup.
+func (mr *MockWorkloadGroupClientMockRecorder) ListWorkloadGroup(ctx interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWorkloadGroup", reflect.TypeOf((*MockWorkloadGroupClient)(nil).ListWorkloadGroup), varargs...)
+}
+
+// PatchWorkloadGroup mocks base method.
+func (m *MockWorkloadGroupClient) PatchWorkloadGroup(ctx context.Context, obj *v1beta10.WorkloadGroup, patch client.Patch, opts ...client.PatchOption) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, obj, patch}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "PatchWorkloadGroup", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PatchWorkloadGroup indicates an expected call of PatchWorkloadGroup.
+func (mr *MockWorkloadGroupClientMockRecorder) PatchWorkloadGroup(ctx, obj, patch interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, obj, patch}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchWorkloadGroup", reflect.TypeOf((*MockWorkloadGroupClient)(nil).PatchWorkloadGroup), varargs...)
+}
+
+// PatchWorkloadGroupStatus mocks base method.
+func (m *MockWorkloadGroupClient) PatchWorkloadGroupStatus(ctx context.Context, obj *v1beta10.WorkloadGroup, patch client.Patch, opts ...client.PatchOption) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, obj, patch}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "PatchWorkloadGroupStatus", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PatchWorkloadGroupStatus indicates an expected call of PatchWorkloadGroupStatus.
+func (mr *MockWorkloadGroupClientMockRecorder) PatchWorkloadGroupStatus(ctx, obj, patch interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, obj, patch}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchWorkloadGroupStatus", reflect.TypeOf((*MockWorkloadGroupClient)(nil).PatchWorkloadGroupStatus), varargs...)
+}
+
+// UpdateWorkloadGroup mocks base method.
+func (m *MockWorkloadGroupClient) UpdateWorkloadGroup(ctx context.Context, obj *v1beta10.WorkloadGroup, opts ...client.UpdateOption) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, obj}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpdateWorkloadGroup", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateWorkloadGroup indicates an expected call of UpdateWorkloadGroup.
+func (mr *MockWorkloadGroupClientMockRecorder) UpdateWorkloadGroup(ctx, obj interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, obj}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkloadGroup", reflect.TypeOf((*MockWorkloadGroupClient)(nil).UpdateWorkloadGroup), varargs...)
+}
+
+// UpdateWorkloadGroupStatus mocks base method.
+func (m *MockWorkloadGroupClient) UpdateWorkloadGroupStatus(ctx context.Context, obj *v1beta10.WorkloadGroup, opts ...client.UpdateOption) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, obj}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpdateWorkloadGroupStatus", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateWorkloadGroupStatus indicates an expected call of UpdateWorkloadGroupStatus.
+func (mr *MockWorkloadGroupClientMockRecorder) UpdateWorkloadGroupStatus(ctx, obj interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, obj}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkloadGroupStatus", reflect.TypeOf((*MockWorkloadGroupClient)(nil).UpdateWorkloadGroupStatus), varargs...)
+}
+
+// UpsertWorkloadGroup mocks base method.
+func (m *MockWorkloadGroupClient) UpsertWorkloadGroup(ctx context.Context, obj *v1beta10.WorkloadGroup, transitionFuncs ...v1beta1.WorkloadGroupTransitionFunction) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, obj}
+	for _, a := range transitionFuncs {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpsertWorkloadGroup", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpsertWorkloadGroup indicates an expected call of UpsertWorkloadGroup.
+func (mr *MockWorkloadGroupClientMockRecorder) UpsertWorkloadGroup(ctx, obj interface{}, transitionFuncs ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, obj}, transitionFuncs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertWorkloadGroup", reflect.TypeOf((*MockWorkloadGroupClient)(nil).UpsertWorkloadGroup), varargs...)
+}
+
+// MockMulticlusterWorkloadGroupClient is a mock of MulticlusterWorkloadGroupClient interface.
+type MockMulticlusterWorkloadGroupClient struct {
+	ctrl     *gomock.Controller
+	recorder *MockMulticlusterWorkloadGroupClientMockRecorder
+}
+
+// MockMulticlusterWorkloadGroupClientMockRecorder is the mock recorder for MockMulticlusterWorkloadGroupClient.
+type MockMulticlusterWorkloadGroupClientMockRecorder struct {
+	mock *MockMulticlusterWorkloadGroupClient
+}
+
+// NewMockMulticlusterWorkloadGroupClient creates a new mock instance.
+func NewMockMulticlusterWorkloadGroupClient(ctrl *gomock.Controller) *MockMulticlusterWorkloadGroupClient {
+	mock := &MockMulticlusterWorkloadGroupClient{ctrl: ctrl}
+	mock.recorder = &MockMulticlusterWorkloadGroupClientMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockMulticlusterWorkloadGroupClient) EXPECT() *MockMulticlusterWorkloadGroupClientMockRecorder {
+	return m.recorder
+}
+
+// Cluster mocks base method.
+func (m *MockMulticlusterWorkloadGroupClient) Cluster(cluster string) (v1beta1.WorkloadGroupClient, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Cluster", cluster)
+	ret0, _ := ret[0].(v1beta1.WorkloadGroupClient)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Cluster indicates an expected call of Cluster.
+func (mr *MockMulticlusterWorkloadGroupClientMockRecorder) Cluster(cluster interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cluster", reflect.TypeOf((*MockMulticlusterWorkloadGroupClient)(nil).Cluster), cluster)
 }
 
 // MockVirtualServiceReader is a mock of VirtualServiceReader interface.

--- a/pkg/api/istio/networking.istio.io/v1beta1/providers/client_providers.go
+++ b/pkg/api/istio/networking.istio.io/v1beta1/providers/client_providers.go
@@ -129,6 +129,34 @@ func WorkloadEntryClientFromConfigFactoryProvider() WorkloadEntryClientFromConfi
 	}
 }
 
+// Provider for WorkloadGroupClient from Clientset
+func WorkloadGroupClientFromClientsetProvider(clients networking_istio_io_v1beta1.Clientset) networking_istio_io_v1beta1.WorkloadGroupClient {
+	return clients.WorkloadGroups()
+}
+
+// Provider for WorkloadGroup Client from Client
+func WorkloadGroupClientProvider(client client.Client) networking_istio_io_v1beta1.WorkloadGroupClient {
+	return networking_istio_io_v1beta1.NewWorkloadGroupClient(client)
+}
+
+type WorkloadGroupClientFactory func(client client.Client) networking_istio_io_v1beta1.WorkloadGroupClient
+
+func WorkloadGroupClientFactoryProvider() WorkloadGroupClientFactory {
+	return WorkloadGroupClientProvider
+}
+
+type WorkloadGroupClientFromConfigFactory func(cfg *rest.Config) (networking_istio_io_v1beta1.WorkloadGroupClient, error)
+
+func WorkloadGroupClientFromConfigFactoryProvider() WorkloadGroupClientFromConfigFactory {
+	return func(cfg *rest.Config) (networking_istio_io_v1beta1.WorkloadGroupClient, error) {
+		clients, err := networking_istio_io_v1beta1.NewClientsetFromConfig(cfg)
+		if err != nil {
+			return nil, err
+		}
+		return clients.WorkloadGroups(), nil
+	}
+}
+
 // Provider for VirtualServiceClient from Clientset
 func VirtualServiceClientFromClientsetProvider(clients networking_istio_io_v1beta1.Clientset) networking_istio_io_v1beta1.VirtualServiceClient {
 	return clients.VirtualServices()

--- a/pkg/api/istio/networking.istio.io/v1beta1/sets/mocks/sets.go
+++ b/pkg/api/istio/networking.istio.io/v1beta1/sets/mocks/sets.go
@@ -1039,6 +1039,262 @@ func (mr *MockWorkloadEntrySetMockRecorder) UnsortedList(filterResource ...inter
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnsortedList", reflect.TypeOf((*MockWorkloadEntrySet)(nil).UnsortedList), filterResource...)
 }
 
+// MockWorkloadGroupSet is a mock of WorkloadGroupSet interface.
+type MockWorkloadGroupSet struct {
+	ctrl     *gomock.Controller
+	recorder *MockWorkloadGroupSetMockRecorder
+}
+
+// MockWorkloadGroupSetMockRecorder is the mock recorder for MockWorkloadGroupSet.
+type MockWorkloadGroupSetMockRecorder struct {
+	mock *MockWorkloadGroupSet
+}
+
+// NewMockWorkloadGroupSet creates a new mock instance.
+func NewMockWorkloadGroupSet(ctrl *gomock.Controller) *MockWorkloadGroupSet {
+	mock := &MockWorkloadGroupSet{ctrl: ctrl}
+	mock.recorder = &MockWorkloadGroupSetMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockWorkloadGroupSet) EXPECT() *MockWorkloadGroupSetMockRecorder {
+	return m.recorder
+}
+
+// Clone mocks base method.
+func (m *MockWorkloadGroupSet) Clone() v1beta1sets.WorkloadGroupSet {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Clone")
+	ret0, _ := ret[0].(v1beta1sets.WorkloadGroupSet)
+	return ret0
+}
+
+// Clone indicates an expected call of Clone.
+func (mr *MockWorkloadGroupSetMockRecorder) Clone() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clone", reflect.TypeOf((*MockWorkloadGroupSet)(nil).Clone))
+}
+
+// Delete mocks base method.
+func (m *MockWorkloadGroupSet) Delete(workloadGroup ezkube.ResourceId) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Delete", workloadGroup)
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockWorkloadGroupSetMockRecorder) Delete(workloadGroup interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockWorkloadGroupSet)(nil).Delete), workloadGroup)
+}
+
+// Delta mocks base method.
+func (m *MockWorkloadGroupSet) Delta(newSet v1beta1sets.WorkloadGroupSet) sets.ResourceDelta {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delta", newSet)
+	ret0, _ := ret[0].(sets.ResourceDelta)
+	return ret0
+}
+
+// Delta indicates an expected call of Delta.
+func (mr *MockWorkloadGroupSetMockRecorder) Delta(newSet interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delta", reflect.TypeOf((*MockWorkloadGroupSet)(nil).Delta), newSet)
+}
+
+// Difference mocks base method.
+func (m *MockWorkloadGroupSet) Difference(set v1beta1sets.WorkloadGroupSet) v1beta1sets.WorkloadGroupSet {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Difference", set)
+	ret0, _ := ret[0].(v1beta1sets.WorkloadGroupSet)
+	return ret0
+}
+
+// Difference indicates an expected call of Difference.
+func (mr *MockWorkloadGroupSetMockRecorder) Difference(set interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Difference", reflect.TypeOf((*MockWorkloadGroupSet)(nil).Difference), set)
+}
+
+// Equal mocks base method.
+func (m *MockWorkloadGroupSet) Equal(workloadGroupSet v1beta1sets.WorkloadGroupSet) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Equal", workloadGroupSet)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// Equal indicates an expected call of Equal.
+func (mr *MockWorkloadGroupSetMockRecorder) Equal(workloadGroupSet interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Equal", reflect.TypeOf((*MockWorkloadGroupSet)(nil).Equal), workloadGroupSet)
+}
+
+// Find mocks base method.
+func (m *MockWorkloadGroupSet) Find(id ezkube.ResourceId) (*v1beta1.WorkloadGroup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Find", id)
+	ret0, _ := ret[0].(*v1beta1.WorkloadGroup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Find indicates an expected call of Find.
+func (mr *MockWorkloadGroupSetMockRecorder) Find(id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Find", reflect.TypeOf((*MockWorkloadGroupSet)(nil).Find), id)
+}
+
+// Generic mocks base method.
+func (m *MockWorkloadGroupSet) Generic() sets.ResourceSet {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Generic")
+	ret0, _ := ret[0].(sets.ResourceSet)
+	return ret0
+}
+
+// Generic indicates an expected call of Generic.
+func (mr *MockWorkloadGroupSetMockRecorder) Generic() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Generic", reflect.TypeOf((*MockWorkloadGroupSet)(nil).Generic))
+}
+
+// Has mocks base method.
+func (m *MockWorkloadGroupSet) Has(workloadGroup ezkube.ResourceId) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Has", workloadGroup)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// Has indicates an expected call of Has.
+func (mr *MockWorkloadGroupSetMockRecorder) Has(workloadGroup interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Has", reflect.TypeOf((*MockWorkloadGroupSet)(nil).Has), workloadGroup)
+}
+
+// Insert mocks base method.
+func (m *MockWorkloadGroupSet) Insert(workloadGroup ...*v1beta1.WorkloadGroup) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{}
+	for _, a := range workloadGroup {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "Insert", varargs...)
+}
+
+// Insert indicates an expected call of Insert.
+func (mr *MockWorkloadGroupSetMockRecorder) Insert(workloadGroup ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Insert", reflect.TypeOf((*MockWorkloadGroupSet)(nil).Insert), workloadGroup...)
+}
+
+// Intersection mocks base method.
+func (m *MockWorkloadGroupSet) Intersection(set v1beta1sets.WorkloadGroupSet) v1beta1sets.WorkloadGroupSet {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Intersection", set)
+	ret0, _ := ret[0].(v1beta1sets.WorkloadGroupSet)
+	return ret0
+}
+
+// Intersection indicates an expected call of Intersection.
+func (mr *MockWorkloadGroupSetMockRecorder) Intersection(set interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Intersection", reflect.TypeOf((*MockWorkloadGroupSet)(nil).Intersection), set)
+}
+
+// Keys mocks base method.
+func (m *MockWorkloadGroupSet) Keys() sets0.String {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Keys")
+	ret0, _ := ret[0].(sets0.String)
+	return ret0
+}
+
+// Keys indicates an expected call of Keys.
+func (mr *MockWorkloadGroupSetMockRecorder) Keys() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Keys", reflect.TypeOf((*MockWorkloadGroupSet)(nil).Keys))
+}
+
+// Length mocks base method.
+func (m *MockWorkloadGroupSet) Length() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Length")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// Length indicates an expected call of Length.
+func (mr *MockWorkloadGroupSetMockRecorder) Length() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Length", reflect.TypeOf((*MockWorkloadGroupSet)(nil).Length))
+}
+
+// List mocks base method.
+func (m *MockWorkloadGroupSet) List(filterResource ...func(*v1beta1.WorkloadGroup) bool) []*v1beta1.WorkloadGroup {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{}
+	for _, a := range filterResource {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "List", varargs...)
+	ret0, _ := ret[0].([]*v1beta1.WorkloadGroup)
+	return ret0
+}
+
+// List indicates an expected call of List.
+func (mr *MockWorkloadGroupSetMockRecorder) List(filterResource ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockWorkloadGroupSet)(nil).List), filterResource...)
+}
+
+// Map mocks base method.
+func (m *MockWorkloadGroupSet) Map() map[string]*v1beta1.WorkloadGroup {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Map")
+	ret0, _ := ret[0].(map[string]*v1beta1.WorkloadGroup)
+	return ret0
+}
+
+// Map indicates an expected call of Map.
+func (mr *MockWorkloadGroupSetMockRecorder) Map() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Map", reflect.TypeOf((*MockWorkloadGroupSet)(nil).Map))
+}
+
+// Union mocks base method.
+func (m *MockWorkloadGroupSet) Union(set v1beta1sets.WorkloadGroupSet) v1beta1sets.WorkloadGroupSet {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Union", set)
+	ret0, _ := ret[0].(v1beta1sets.WorkloadGroupSet)
+	return ret0
+}
+
+// Union indicates an expected call of Union.
+func (mr *MockWorkloadGroupSetMockRecorder) Union(set interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Union", reflect.TypeOf((*MockWorkloadGroupSet)(nil).Union), set)
+}
+
+// UnsortedList mocks base method.
+func (m *MockWorkloadGroupSet) UnsortedList(filterResource ...func(*v1beta1.WorkloadGroup) bool) []*v1beta1.WorkloadGroup {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{}
+	for _, a := range filterResource {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UnsortedList", varargs...)
+	ret0, _ := ret[0].([]*v1beta1.WorkloadGroup)
+	return ret0
+}
+
+// UnsortedList indicates an expected call of UnsortedList.
+func (mr *MockWorkloadGroupSetMockRecorder) UnsortedList(filterResource ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnsortedList", reflect.TypeOf((*MockWorkloadGroupSet)(nil).UnsortedList), filterResource...)
+}
+
 // MockVirtualServiceSet is a mock of VirtualServiceSet interface.
 type MockVirtualServiceSet struct {
 	ctrl     *gomock.Controller

--- a/pkg/api/istio/networking.istio.io/v1beta1/type_helpers.go
+++ b/pkg/api/istio/networking.istio.io/v1beta1/type_helpers.go
@@ -19,6 +19,9 @@ type ServiceEntrySlice []*ServiceEntry
 // WorkloadEntrySlice represents a slice of *WorkloadEntry
 type WorkloadEntrySlice []*WorkloadEntry
 
+// WorkloadGroupSlice represents a slice of *WorkloadGroup
+type WorkloadGroupSlice []*WorkloadGroup
+
 // VirtualServiceSlice represents a slice of *VirtualService
 type VirtualServiceSlice []*VirtualService
 


### PR DESCRIPTION
This is required for Gloo Mesh to be able to output Istio WorkloadGroup resources for external workloads represented by an ExternalWorkload resource. ExternalWorkload is a new custom resource that will be introduced as a part of Gloo Fabric to allow routing to managed VM/bare-metal workload instances.